### PR TITLE
Webview non pure component results in loss of reference

### DIFF
--- a/src/withWebViewBridge.tsx
+++ b/src/withWebViewBridge.tsx
@@ -101,6 +101,7 @@ export const withWebViewBridge = function<WebViewType extends BaseWebViewType, W
         }
 
         /* private */ async _onWebViewMessage(event: any) {
+            const requestingWebview = this.webview;
             if (this.props.onMessage) {
                 event.persist();
             }
@@ -127,7 +128,7 @@ export const withWebViewBridge = function<WebViewType extends BaseWebViewType, W
 
                     try {
                         //language=JavaScript
-                        this.webview.injectJavaScript(`
+                        requestingWebview.injectJavaScript(`
                             window.postMessage(${JSON.stringify({
                                 type: 'functionResponse',
                                 invocationId: obj.invocationId,
@@ -143,7 +144,7 @@ export const withWebViewBridge = function<WebViewType extends BaseWebViewType, W
                 } catch (e) {
                     try {
                         //language=JavaScript
-                        this.webview.injectJavaScript(`
+                        requestingWebview.injectJavaScript(`
                         window.postMessage(${JSON.stringify({
                             type: 'functionRejection',
                             invocationId: obj.invocationId,


### PR DESCRIPTION
Based on the extra logs added in the last PR I found out the bridge is timing out because the callback is unable to reach the webview since the `ref=(webview => this.webview = webview)` is invoked with null.

According to the react documentation this happens when the component was unmounted or is about to be re-rendered with new props. The best practice to resolve redundant rendering is to extend PureComponent. Unfortunately it is not possible with components that have an internal state that can be controlled with the view reference.

I could override `shouldUpdateComponent` and decide for myself if I should re-render the component but that would be very risky as the component is generic and I might drop a necessary update. In addition it won't resolve the following race condition:

1. you invoke a long running task (for example capturing an image)
2. you invoke a short running task that changes the webview props (for example turn off the camera flash)
3. the webview will unmount because we need to re-render it with new props (`flash={true}`) 
4. image capture finishes and we try to post a message to the webview that was set to null

I choose to go with the simplest fix to avoid introducing new bugs. once I get a message from the webview I store a reference to the webview to be notified with the results even if it gets unmount.

The react native webview is backed up by a native component that never actually re-renders. What's happening is that the new reference is set to null for a short period of time and you immediately get a new reference that is backed up by the same native webview.

This PR could potentially introduce an issue where we try to invoke `injectJavascript` when the component was truly unmounted but I am certain that the scale of the issue will be really low compared to this one. 
